### PR TITLE
Add maxDaysForecast config 

### DIFF
--- a/MMM-forecast-io.js
+++ b/MMM-forecast-io.js
@@ -17,6 +17,7 @@ Module.register("MMM-forecast-io", {
     latitude:  null,
     longitude: null,
     showForecast: true,
+    maxDaysForecast: 7,   // maximum number of days to show in forecast
     showPrecipitationGraph: true,
     precipitationGraphWidth: 400,
     precipitationProbabilityThreshold: 0.1,
@@ -311,7 +312,7 @@ Module.register("MMM-forecast-io", {
   },
 
   renderWeatherForecast: function () {
-    var numDays =  7;
+    var numDays =  this.config.maxDaysForecast;
     var i;
 
     var filteredDays =

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ modules: [
       </td>
     </tr>
     <tr>
-      <td><code>showForcast</code></td>
+      <td><code>showForecast</code></td>
       <td>Toggles display of the seven-day weather forecast.<br>
         <br><b>Default value:</b>  <code>true</code>
       </td>

--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ modules: [
       </td>
     </tr>
     <tr>
+      <td><code>maxDaysForecast</code></td>
+      <td>Limit how many days of weather forecast. Useful values 1-7<br>
+        <br><b>Default value:</b>  <code>7</code>
+      </td>
+    </tr>
+    <tr>
       <td><code>showPrecipitationGraph</code></td>
       <td>Toggles display of the precipitation graph.<br>
         <br><b>Default value:</b>  <code>true</code>


### PR DESCRIPTION
Add maxDaysForecast option to configuration to add the ability to limit the number of days in the forecast to something less than the default 7 days.