### PR TITLE
switching to currentWeather.icon with hourly.icon fallback

### DIFF
--- a/MMM-forecast-io.js
+++ b/MMM-forecast-io.js
@@ -139,8 +139,8 @@ Module.register("MMM-forecast-io", {
     var large = document.createElement("div");
     large.className = "large light";
 
-    var icon = minutely ? minutely.icon : hourly.icon;
-    var iconClass = this.config.iconTable[hourly.icon];
+    var icon = currentWeather ? currentWeather.icon : hourly.icon;
+    var iconClass = this.config.iconTable[icon];
     var icon = document.createElement("span");
     icon.className = 'big-icon wi ' + iconClass;
     large.appendChild(icon);


### PR DESCRIPTION
Sorry it took me forever to submit this PR. Somehow I missed your comment on the issue.

Fixes #8

Summary:

It seems that following logic is always using `hourly.icon` even if `minutely` is available.

```
var icon = minutely ? minutely.icon : hourly.icon;
var iconClass = this.config.iconTable[hourly.icon];
```

Source: https://github.com/dmcinnes/MMM-forecast-io/blob/master/MMM-forecast-io.js#L150

Also it seems since this icon is displayed for current conditions it would be better to use `currentWeather.icon` and then fall back on `hourly.icon`.