### PR TITLE
Added 'precipitationFillColor' to list of configurable options

### DIFF
--- a/MMM-forecast-io.js
+++ b/MMM-forecast-io.js
@@ -21,6 +21,7 @@ Module.register("MMM-forecast-io", {
     enablePrecipitationGraph: true,
     alwaysShowPrecipitationGraph: false,
     precipitationGraphWidth: 400,
+    precipitationFillColor: 'white',
     precipitationProbabilityThreshold: 0.1,
     precipitationIntensityScaleTop: 0.2,
     unitTable: {
@@ -238,7 +239,7 @@ Module.register("MMM-forecast-io", {
     var stepSize = Math.round(width / data.length);
     context.save();
     context.strokeStyle = 'white';
-    context.fillStyle = 'white';
+    context.fillStyle = this.config.precipitationFillColor;
     context.globalCompositeOperation = 'xor';
     context.beginPath();
     context.moveTo(0, height);

--- a/README.md
+++ b/README.md
@@ -126,8 +126,14 @@ modules: [
     </tr>
     <tr>
       <td><code>alwaysShowPrecipitationGraph</code></td>
-      <td>Force the precipition graph to always show, and not just when it's raining..<br>
+      <td>Force the precipition graph to always show, and not just when it's raining.<br>
         <br><b>Default value:</b>  <code>false</code>
+      </td>
+    </tr>
+     <tr>
+      <td><code>precipitationFillColor</code></td>
+      <td>Choose the color of the precipitation graph. Will accept hex value or color names of Javascript-friendly colors. See <a href="http://www.javascripter.net/faq/colornam.htm">this page</a> for a list of colors. "dodgerblue" appears to best mimic the Dark Sky app.<br>
+        <br><b>Default value:</b>  <code>white</code>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Set the default color to 'white' to match what was previously coded, but added option accessible from ```config.js```.  I also updated the table in the readme accordingly, including a link to a list of java-friendly color names and the one that (in my brief testing) best matched the original Dark Sky app. 

Feel free to change anything I did, I'm very new at this!