### PR TITLE
added variable forecast table font size

### DIFF
--- a/MMM-forecast-io.js
+++ b/MMM-forecast-io.js
@@ -18,6 +18,7 @@ Module.register("MMM-forecast-io", {
     latitude:  null,
     longitude: null,
     showForecast: true,
+    forecastTableFontSize: 'medium',
     maxDaysForecast: 7,   // maximum number of days to show in forecast
     enablePrecipitationGraph: true,
     alwaysShowPrecipitationGraph: false,
@@ -367,7 +368,7 @@ Module.register("MMM-forecast-io", {
     max = Math.round(max);
 
     var display = document.createElement("table");
-    display.className = "forecast";
+    display.className = this.config.forecastTableFontSize + " forecast";
     for (i = 0; i < filteredDays.length; i++) {
       var day = filteredDays[i];
       var row = this.renderForecastRow(day, min, max);

--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ modules: [
       </td>
     </tr>
     <tr>
+      <td><code>forecastTableFontSize</code></td>
+      <td>Sets CSS font style for forecast table. Possible values: <code>'xsmall'</code>, <code>'small'</code>, <code>'medium'</code>, <code>'large'</code>, <code>'xlarge'</code><br>
+        <br><b>Default value:</b>  <code>'medium'</code>
+      </td>
+    </tr>
+    <tr>
       <td><code>precipitationProbabilityThreshold</code></td>
       <td>Probability threshold at which rain is rendered onto the precipitation graph.<br>
           See the <a href="https://darksky.net/dev/docs/response#data-point">Darksky.net API documentation</a> for more details.<br>


### PR DESCRIPTION
added ability to change look and feel of the forecast table font size by utilizing CSS classes from `main.css`

it looks like this with `small` setting:
![image](https://user-images.githubusercontent.com/1007608/48964937-d2aca580-ef67-11e8-8634-4bb72648736f.png)
