### PR TITLE
Fixes missing indoor temperature icon

### DIFF
--- a/MMM-forecast-io.js
+++ b/MMM-forecast-io.js
@@ -62,7 +62,7 @@ Module.register("MMM-forecast-io", {
   },
 
   getStyles: function () {
-    return ["weather-icons.css", "MMM-forecast-io.css"];
+    return ["font-awesome.css", "weather-icons.css", "MMM-forecast-io.css"];
   },
 
   shouldLookupGeolocation: function () {


### PR DESCRIPTION
The indoor temperature icon was missing if no calendar module was used, because the `font-awesome.css` file wasn't loaded.

This file is in the vendor folder and available for every module.