### PR TITLE
Addition of a "feels like" temperature option

### DIFF
--- a/MMM-forecast-io.js
+++ b/MMM-forecast-io.js
@@ -5,6 +5,7 @@ Module.register("MMM-forecast-io", {
     apiBase: "https://api.darksky.net/forecast",
     units: config.units,
     language: config.language,
+    showIndoorTemperature: false,
     updateInterval: 5 * 60 * 1000, // every 5 minutes
     animationSpeed: 1000,
     initialLoadDelay: 0, // 0 seconds delay
@@ -16,15 +17,12 @@ Module.register("MMM-forecast-io", {
     },
     latitude:  null,
     longitude: null,
-    showCurrentWeather: true,
-    showIndoorTemperature: false,
-    showTextSummary: true,
-    showWind: true,
-    showSunriseSunset: true,
     showForecast: true,
-    fadeForecast: false,
+    showFeelsLike: false, // new FeelsLike option
     forecastTableFontSize: 'medium',
     maxDaysForecast: 7,   // maximum number of days to show in forecast
+    showWind: true,
+    showSunriseSunset: true,
     enablePrecipitationGraph: true,
     alwaysShowPrecipitationGraph: false,
     showDailyPrecipitationChance: true,
@@ -116,6 +114,7 @@ Module.register("MMM-forecast-io", {
     }
     this.loaded = true;
     this.weatherData = data;
+    this.feelsLike = this.roundTemp(this.weatherData.currently.apparentTemperature); // process feelsLike data
     this.temp = this.roundTemp(this.weatherData.currently.temperature);
     this.updateDom(this.config.animationSpeed);
     this.scheduleUpdate();
@@ -171,18 +170,16 @@ Module.register("MMM-forecast-io", {
     var large = document.createElement("div");
     large.className = "large light";
 
-    if(this.config.showCurrentWeather) {
-      var icon = currentWeather ? currentWeather.icon : hourly.icon;
-      var iconClass = this.config.iconTable[icon];
-      var icon = document.createElement("span");
-      icon.className = 'big-icon wi ' + iconClass;
-      large.appendChild(icon);
+    var icon = currentWeather ? currentWeather.icon : hourly.icon;
+    var iconClass = this.config.iconTable[icon];
+    var icon = document.createElement("span");
+    icon.className = 'big-icon wi ' + iconClass;
+    large.appendChild(icon);
 
-      var temperature = document.createElement("span");
-      temperature.className = "bright";
-      temperature.innerHTML = " " + this.temp + "&deg;";
-      large.appendChild(temperature);
-    }
+    var temperature = document.createElement("span");
+    temperature.className = "bright";
+    temperature.innerHTML = " " + this.temp + "&deg;";
+    large.appendChild(temperature);
 
     if (this.roomTemperature !== undefined) {
       var icon = document.createElement("span");
@@ -194,6 +191,15 @@ Module.register("MMM-forecast-io", {
       temperature.innerHTML = " " + this.roomTemperature + "&deg;";
       large.appendChild(temperature);
     }
+
+/* --- new FeelsLike row --- */
+    if (this.config.showFeelsLike || (this.temp - this.feelsLike > 1) || (this.feelsLike - this.temp > 1) ) {
+      var feelsLike = document.createElement("div");
+      feelsLike.className = "medium bright";
+      feelsLike.innerHTML = "Feels like  " + this.feelsLike + "&deg;";
+      large.appendChild(feelsLike);
+    }
+/* --- --- */
 
     var wind = document.createElement("div");
     wind.className = "small dimmed wind";
@@ -232,16 +238,14 @@ Module.register("MMM-forecast-io", {
     var sunsetTime = document.createElement("span");
     sunsetTime.innerHTML = moment(new Date(daily.data[0].sunsetTime * 1000)).format("LT");
     sunriseSunset.appendChild(sunsetTime);
-    
-    wrapper.appendChild(large);
 
-    if (this.config.showTextSummary) {
-      var summaryText = minutely ? minutely.summary : hourly.summary;
-      var summary = document.createElement("div");
-      summary.className = "small dimmed summary";
-      summary.innerHTML = summaryText;
-      wrapper.appendChild(summary);
-    }
+    var summaryText = minutely ? minutely.summary : hourly.summary;
+    var summary = document.createElement("div");
+    summary.className = "small /*dimmed*/ summary";
+    summary.innerHTML = summaryText;
+
+    wrapper.appendChild(large);
+    wrapper.appendChild(summary);
 
     if (this.config.showSunriseSunset) {
       wrapper.appendChild(sunriseSunset);
@@ -353,14 +357,14 @@ Module.register("MMM-forecast-io", {
     return moment.weekdaysShort(dt.getDay());
   },
 
-  renderForecastRow: function (data, min, max, addClass) {
+  renderForecastRow: function (data, min, max) {
     var total = max - min;
     var interval = 100 / total;
     var rowMinTemp = this.roundTemp(data.temperatureMin);
     var rowMaxTemp = this.roundTemp(data.temperatureMax);
 
     var row = document.createElement("tr");
-    row.className = "forecast-row" + (addClass ? " " + addClass : "");
+    row.className = "forecast-row";
 
     var dayTextSpan = document.createElement("span");
     dayTextSpan.className = "forecast-day"
@@ -439,16 +443,7 @@ Module.register("MMM-forecast-io", {
     display.className = this.config.forecastTableFontSize + " forecast";
     for (i = 0; i < filteredDays.length; i++) {
       var day = filteredDays[i];
-      var addClass = "";
-      if(this.config.fadeForecast) {
-        if(i+2 == filteredDays.length) {
-          addClass = "dark";
-        }
-        if(i+1 == filteredDays.length) {
-          addClass = "darker";
-        }
-	  }
-      var row = this.renderForecastRow(day, min, max, addClass);
+      var row = this.renderForecastRow(day, min, max);
       display.appendChild(row);
     }
     return display;

--- a/MMM-forecast-io.js
+++ b/MMM-forecast-io.js
@@ -128,7 +128,7 @@ Module.register("MMM-forecast-io", {
       console.log('process weather error', error);
     }
     // try later
-   this.scheduleUpdate();
+    this.scheduleUpdate();
   },
 
   notificationReceived: function(notification, payload, sender) {
@@ -173,7 +173,7 @@ Module.register("MMM-forecast-io", {
     var large = document.createElement("div");
     large.className = "large light";
 
-   if(this.config.showCurrentWeather) {
+    if(this.config.showCurrentWeather) {
       var icon = currentWeather ? currentWeather.icon : hourly.icon;
       var iconClass = this.config.iconTable[icon];
       var icon = document.createElement("span");

--- a/MMM-forecast-io.js
+++ b/MMM-forecast-io.js
@@ -5,7 +5,6 @@ Module.register("MMM-forecast-io", {
     apiBase: "https://api.darksky.net/forecast",
     units: config.units,
     language: config.language,
-    showIndoorTemperature: false,
     updateInterval: 5 * 60 * 1000, // every 5 minutes
     animationSpeed: 1000,
     initialLoadDelay: 0, // 0 seconds delay
@@ -17,12 +16,16 @@ Module.register("MMM-forecast-io", {
     },
     latitude:  null,
     longitude: null,
+    showCurrentWeather: true,
+    showIndoorTemperature: false,
+    showTextSummary: true,
+    showWind: true,
+    showSunriseSunset: true,
     showForecast: true,
+    fadeForecast: false,
     showFeelsLike: false, // new FeelsLike option
     forecastTableFontSize: 'medium',
     maxDaysForecast: 7,   // maximum number of days to show in forecast
-    showWind: true,
-    showSunriseSunset: true,
     enablePrecipitationGraph: true,
     alwaysShowPrecipitationGraph: false,
     showDailyPrecipitationChance: true,
@@ -125,7 +128,7 @@ Module.register("MMM-forecast-io", {
       console.log('process weather error', error);
     }
     // try later
-    this.scheduleUpdate();
+   this.scheduleUpdate();
   },
 
   notificationReceived: function(notification, payload, sender) {
@@ -170,16 +173,18 @@ Module.register("MMM-forecast-io", {
     var large = document.createElement("div");
     large.className = "large light";
 
-    var icon = currentWeather ? currentWeather.icon : hourly.icon;
-    var iconClass = this.config.iconTable[icon];
-    var icon = document.createElement("span");
-    icon.className = 'big-icon wi ' + iconClass;
-    large.appendChild(icon);
+   if(this.config.showCurrentWeather) {
+      var icon = currentWeather ? currentWeather.icon : hourly.icon;
+      var iconClass = this.config.iconTable[icon];
+      var icon = document.createElement("span");
+      icon.className = 'big-icon wi ' + iconClass;
+      large.appendChild(icon);
 
-    var temperature = document.createElement("span");
-    temperature.className = "bright";
-    temperature.innerHTML = " " + this.temp + "&deg;";
-    large.appendChild(temperature);
+      var temperature = document.createElement("span");
+      temperature.className = "bright";
+      temperature.innerHTML = " " + this.temp + "&deg;";
+      large.appendChild(temperature);
+    }
 
     if (this.roomTemperature !== undefined) {
       var icon = document.createElement("span");
@@ -239,13 +244,15 @@ Module.register("MMM-forecast-io", {
     sunsetTime.innerHTML = moment(new Date(daily.data[0].sunsetTime * 1000)).format("LT");
     sunriseSunset.appendChild(sunsetTime);
 
-    var summaryText = minutely ? minutely.summary : hourly.summary;
-    var summary = document.createElement("div");
-    summary.className = "small /*dimmed*/ summary";
-    summary.innerHTML = summaryText;
-
     wrapper.appendChild(large);
-    wrapper.appendChild(summary);
+
+    if (this.config.showTextSummary) {
+      var summaryText = minutely ? minutely.summary : hourly.summary;
+      var summary = document.createElement("div");
+      summary.className = "small dimmed summary";
+      summary.innerHTML = summaryText;
+      wrapper.appendChild(summary);
+    }
 
     if (this.config.showSunriseSunset) {
       wrapper.appendChild(sunriseSunset);
@@ -357,14 +364,14 @@ Module.register("MMM-forecast-io", {
     return moment.weekdaysShort(dt.getDay());
   },
 
-  renderForecastRow: function (data, min, max) {
+  renderForecastRow: function (data, min, max, addClass) {
     var total = max - min;
     var interval = 100 / total;
     var rowMinTemp = this.roundTemp(data.temperatureMin);
     var rowMaxTemp = this.roundTemp(data.temperatureMax);
 
     var row = document.createElement("tr");
-    row.className = "forecast-row";
+    row.className = "forecast-row" + (addClass ? " " + addClass : "");
 
     var dayTextSpan = document.createElement("span");
     dayTextSpan.className = "forecast-day"
@@ -443,7 +450,16 @@ Module.register("MMM-forecast-io", {
     display.className = this.config.forecastTableFontSize + " forecast";
     for (i = 0; i < filteredDays.length; i++) {
       var day = filteredDays[i];
-      var row = this.renderForecastRow(day, min, max);
+      var addClass = "";
+      if(this.config.fadeForecast) {
+        if(i+2 == filteredDays.length) {
+          addClass = "dark";
+        }
+        if(i+1 == filteredDays.length) {
+          addClass = "darker";
+        }
+	  }
+      var row = this.renderForecastRow(day, min, max, addClass);
       display.appendChild(row);
     }
     return display;

--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ modules: [
       </td>
     </tr>
     <tr>
+      <td><code>showFeelsLike</code></td>
+      <td>Toggles display of the local "feels like" temperature. Feels like is the ambient air temperature, adjusted for relative humidity and wind speed to determine how weather conditions feel to bare skin.<br>
+        <br><b>Default value:</b>  <code>false</code>
+      </td>
+    </tr>
+    <tr>
       <td><code>fadeForecast</code></td>
       <td>Toggles fading of last 2 forecast rows.<br>
         <br><b>Default value:</b>  <code>false</code>


### PR DESCRIPTION
I've been tinkering with a "feels like" temperature display option that shows the humidity / wind adjusted outdoor temperature. It's useful for wind-chill and heat-index impacted areas, especially if you plan to spend time outside. When enabled in a config file, the Feels Like display will only appear if the Feels Like temperature is more than a degree different than the ambient. 

<img width="352" alt="Example" src="https://user-images.githubusercontent.com/26437574/103488512-22aef500-4ddb-11eb-99d6-5b71bdef903f.png">
