### PR TITLE
Correction to ensure the FeelsLike feature doesn't activate inadvertently

### DIFF
--- a/MMM-forecast-io.js
+++ b/MMM-forecast-io.js
@@ -198,7 +198,7 @@ Module.register("MMM-forecast-io", {
     }
 
 /* --- new FeelsLike row --- */
-    if (this.config.showFeelsLike || (this.temp - this.feelsLike > 1) || (this.feelsLike - this.temp > 1) ) {
+    if (this.config.showFeelsLike && ((this.temp - this.feelsLike > 1) || (this.feelsLike - this.temp > 1))) {
       var feelsLike = document.createElement("div");
       feelsLike.className = "medium bright";
       feelsLike.innerHTML = "Feels like  " + this.feelsLike + "&deg;";


### PR DESCRIPTION
Realized some parentheses and logic were out of order, which meant the feels like thing could turn on even if disabled. My bad!